### PR TITLE
Python3: Fix ConfigParser import for python3

### DIFF
--- a/git-format
+++ b/git-format
@@ -33,7 +33,11 @@ import sys
 import errno
 import subprocess
 import difflib
-import ConfigParser
+
+try:
+    import ConfigParser
+except ModuleNotFoundError:
+    import configparser as ConfigParser
 
 
 class UnstagedError(Exception):


### PR DESCRIPTION
Python3: Fix ConfigParser import can continue work with python2